### PR TITLE
Update PGPPacket.m

### DIFF
--- a/ObjectivePGP/PGPPacket.m
+++ b/ObjectivePGP/PGPPacket.m
@@ -260,14 +260,12 @@ const UInt32 UnknownLength = UINT32_MAX;
         UInt8 buf[5] = {0,0,0,0,0};
 
         UInt64 fiveOctets = bodyLength;
-        UInt8 marker = 255;
-        [data appendBytes:&marker length:1];
 
         buf[0] = 0xff;
-		buf[1] = (UInt8)(fiveOctets >> 24);
-		buf[2] = (UInt8)(fiveOctets >> 16);
-		buf[3] = (UInt8)(fiveOctets >> 8);
-		buf[4] = (UInt8)(fiveOctets);
+	buf[1] = (UInt8)(fiveOctets >> 24);
+	buf[2] = (UInt8)(fiveOctets >> 16);
+	buf[3] = (UInt8)(fiveOctets >> 8);
+	buf[4] = (UInt8)(fiveOctets);
         [data appendBytes:buf length:5];
     }
     return [data copy];


### PR DESCRIPTION
When trying to encrypt a file larger then 8383 bytes an incorrect new format (Five-Octet Lengths) packet length is written.
In "PGPPacket.m" on lines 263:266 the single octet holding the value 255 is written twice.