### PR TITLE
Import PGPSecretSubKeyPacket.h instead of PGPSecretSubKeyPacket.m

### DIFF
--- a/ObjectivePGP/PGPKey.m
+++ b/ObjectivePGP/PGPKey.m
@@ -13,7 +13,7 @@
 #import "PGPSignaturePacket.h"
 #import "PGPSignatureSubpacket.h"
 #import "PGPPublicSubKeyPacket.h"
-#import "PGPSecretSubKeyPacket.m"
+#import "PGPSecretSubKeyPacket.h"
 #import "PGPUserAttributePacket.h"
 #import "PGPUserAttributeSubpacket.h"
 #import "PGPSubKey.h"


### PR DESCRIPTION
Fixes Duplicate Symbol compilation problem mentioned in #40 