### PR TITLE
Clear critical bit 7 when parsing signature subpacket type

### DIFF
--- a/ObjectivePGP/PGPSignaturePacket.m
+++ b/ObjectivePGP/PGPSignaturePacket.m
@@ -96,7 +96,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray<PGPSignatureSubpacket *> *)subpacketsOfType:(PGPSignatureSubpacketType)type {
     NSMutableArray *arr = [NSMutableArray<PGPSignatureSubpacket *> array];
     for (PGPSignatureSubpacket *subPacket in self.subpackets) {
-        if (subPacket.type == type) {
+        if ((subPacket.type & 0x7F) == type) {
             [arr addObject:subPacket];
         }
     }

--- a/ObjectivePGP/PGPSignatureSubpacket.m
+++ b/ObjectivePGP/PGPSignatureSubpacket.m
@@ -53,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)parseSubpacketBody:(NSData *)packetBody {
     PGPLogDebug(@"parseSubpacketBody %@, body %@",@(self.type), packetBody);
-    switch (self.type) {
+    switch (self.type & 0x7F) {
         case PGPSignatureSubpacketTypeSignatureCreationTime: // NSDate
         {
             //  5.2.3.4.  Signature Creation Time
@@ -218,7 +218,11 @@ NS_ASSUME_NONNULL_BEGIN
             self.value = [featuresArray copy];
         } break;
         default:
-            PGPLogDebug(@"Unsuported subpacket type %d", self.type);
+            if (self.type & 0x80) {
+                PGPLogError(@"Unsupported critical subpacket type %d", self.type);
+            } else {
+                PGPLogDebug(@"Unsupported subpacket type %d", self.type);
+            }
             break;
     }
 }
@@ -230,7 +234,7 @@ NS_ASSUME_NONNULL_BEGIN
     PGPSignatureSubpacketType type = self.type;
     [data appendBytes:&type length:1];
 
-    switch (self.type) {
+    switch (self.type & 0x7F) {
         case PGPSignatureSubpacketTypeSignatureCreationTime: // NSDate
         {
             let date = PGPCast(self.value, NSDate);
@@ -347,7 +351,11 @@ NS_ASSUME_NONNULL_BEGIN
             [data appendBytes:&flagByte length:sizeof(PGPSignatureFlags)];
         } break;
         default:
-            PGPLogDebug(@"Unsuported subpacket type %d", self.type);
+            if (self.type & 0x80) {
+                PGPLogError(@"Unsupported critical subpacket type %d", self.type);
+            } else {
+                PGPLogDebug(@"Unsupported subpacket type %d", self.type);
+            }
             break;
     }
 


### PR DESCRIPTION
Hi, I'd like to get keys that have critical subpackets working. I spent a bit of time debugging anyway so I wrote some code.

I'm not sure this is what was envisioned when "// TODO: Bit 7 of the subpacket type is the "critical" bit" was commented so I've left it intact https://github.com/krzyzanowskim/ObjectivePGP/blob/develop/ObjectivePGP/PGPSignatureSubpacket.m#L390 . The RFC says 'SHOULD consider the signature to be in error.'...I have to settle for just logging an error.