### PR TITLE
Correct a typo in headers

### DIFF
--- a/ObjectivePGP/ObjectivePGP.h
+++ b/ObjectivePGP/ObjectivePGP.h
@@ -31,7 +31,7 @@ FOUNDATION_EXPORT const unsigned char ObjectivePGPVersionString[];
 #import <ObjectivePGP/PGPCryptoUtils.h>
 #import <ObjectivePGP/PGPLogging.h>
 #import <ObjectivePGP/PGPModificationDetectionCodePacket.h>
-#import <ObjectivePGP/PGPOnePAssSignaturePacket.h>
+#import <ObjectivePGP/PGPOnePassSignaturePacket.h>
 #import <ObjectivePGP/PGPPKCSEme.h>
 #import <ObjectivePGP/PGPPKCSEmsa.h>
 #import <ObjectivePGP/PGPPublicKeyEncryptedSessionKeyPacket.h>


### PR DESCRIPTION
I'm using case-sensitive file system. This typo will result a failure in the compilation.

<img width="919" alt="screen shot 2017-08-12 at 12 53 35 am" src="https://user-images.githubusercontent.com/1270392/29239056-bb4ef6e4-7ef8-11e7-978b-0aa820f825a5.png">
