### PR TITLE
Fix issue #97

### DIFF
--- a/ObjectivePGP.playground/Contents.swift
+++ b/ObjectivePGP.playground/Contents.swift
@@ -9,16 +9,14 @@ let key2 = KeyGenerator().generate(for: "fran@krzyzanowskim.com", passphrase: ni
 let plaintext = Data(bytes: [1,2,3,4,5])
 
 // Encrypt 5 bytes using selected key
-let encryptedBin = try ObjectivePGP.encrypt(plaintext, addSignature: false, using: [key1, key2])
-let encrypted = Armor.armored(encryptedBin, as: .message)
-print(encrypted)
 
-// Sign the encrypted binary
-let signatureBin = try ObjectivePGP.sign(encryptedBin, detached: true, using: [key1])
-let signature = Armor.armored(signatureBin, as: .signature)
-print(signature)
-
-try ObjectivePGP.verify(encryptedBin, withSignature: signatureBin, using: [key1])
-
-let decrypted = try ObjectivePGP.decrypt(encryptedBin, andVerifySignature: false, using: [key1])
-print("Decrypted : \(Array(decrypted))")
+if let pkData = try? key2.export(keyType: .public), let pk = try? ObjectivePGP.readKeys(from: pkData){
+    var keys = pk
+    keys.append(key1)
+    _ = try ObjectivePGP.encrypt(plaintext, addSignature: false, using: keys)
+    do{
+        _ = try ObjectivePGP.encrypt(plaintext, addSignature: true, using: keys)
+    } catch{
+        print(error)
+    }
+}

--- a/ObjectivePGP/ObjectivePGPObject.m
+++ b/ObjectivePGP/ObjectivePGPObject.m
@@ -277,7 +277,16 @@ NS_ASSUME_NONNULL_BEGIN
     NSData *content;
     if (shouldSign) {
         // sign data if requested
-        content = [self sign:dataToEncrypt detached:NO usingKeys:keys passphraseForKey:passphraseForKeyBlock error:error];
+        // sign data if requested
+        let signKeys = [NSMutableArray<PGPKey *> array];
+        for (PGPKey* key in keys){
+            if (key.secretKey && key.signingSecretKey != NULL){
+                [signKeys addObject:key];
+            }
+            
+        }
+        content = [self sign:dataToEncrypt detached:NO usingKeys:signKeys passphraseForKey:passphraseForKeyBlock error:error];
+
     } else {
         // Prepare literal packet
         let literalPacket = [PGPLiteralPacket literalPacket:PGPLiteralPacketBinary withData:dataToEncrypt];

--- a/ObjectivePGP/ObjectivePGPObject.m
+++ b/ObjectivePGP/ObjectivePGPObject.m
@@ -277,16 +277,13 @@ NS_ASSUME_NONNULL_BEGIN
     NSData *content;
     if (shouldSign) {
         // sign data if requested
-        // sign data if requested
         let signKeys = [NSMutableArray<PGPKey *> array];
         for (PGPKey* key in keys){
             if (key.secretKey && key.signingSecretKey != NULL){
                 [signKeys addObject:key];
             }
-            
         }
         content = [self sign:dataToEncrypt detached:NO usingKeys:signKeys passphraseForKey:passphraseForKeyBlock error:error];
-
     } else {
         // Prepare literal packet
         let literalPacket = [PGPLiteralPacket literalPacket:PGPLiteralPacketBinary withData:dataToEncrypt];


### PR DESCRIPTION
Fixes #97 

Hey,

when encrypting and signing in one call (encrypt(... addSignature: true ...)) and keys contains a public key the encryption failed because all keys are used for signing and one is no secret key.
Here is a playground example:
```swift
// Generate new key
let key1 = KeyGenerator().generate(for: "marcin@krzyzanowskim.com", passphrase: nil)
let key2 = KeyGenerator().generate(for: "fran@krzyzanowskim.com", passphrase: nil)
let plaintext = Data(bytes: [1,2,3,4,5])
// Encrypt 5 bytes using selected key
if let pkData = try? key2.export(keyType: .public), let pk = try? ObjectivePGP.readKeys(from: pkData) {
    var keys = pk keys.append(key1)
    _ = try ObjectivePGP.encrypt(plaintext, addSignature: false, using: keys)
    do { 
    _ = try ObjectivePGP.encrypt(plaintext, addSignature: true, using: keys) 
    } catch{ 
    print(error) 
    } 
}
```
I fixed it when calling the signing function in the encryption function one should only consider secret keys.

```objc
if (shouldSign) { // sign data 
    if requested let signKeys = [NSMutableArray<PGPKey *> array]; 
    for (PGPKey* key in keys) { 
        if (key.secretKey && key.signingSecretKey != NULL){ [signKeys addObject:key];
    } 
}

content = [self sign:dataToEncrypt detached:NO usingKeys:signKeys passphraseForKey:passphraseForKeyBlock error:error];
```
When decrypting a message and verification is true, the function returns the decrypted message when the signature is wrong, missing or missing public key. I am not sure how to handle such cases.

Cheers
Oliver
  
  