### PR TITLE
Call readKeysFromPath on ObjectivePGP rather than self

### DIFF
--- a/ObjectivePGP/PGPKeyring.m
+++ b/ObjectivePGP/PGPKeyring.m
@@ -49,7 +49,7 @@
 - (BOOL)importKey:(NSString *)keyIdentifier fromPath:(NSString *)path error:(NSError * __autoreleasing _Nullable *)error {
     let fullPath = [path stringByExpandingTildeInPath];
 
-    let loadedKeys = [self.class readKeysFromPath:fullPath error:error];
+    let loadedKeys = [ObjectivePGP readKeysFromPath:fullPath error:error];
     if (loadedKeys.count == 0 || (error && *error)) {
         return NO;
     }


### PR DESCRIPTION
I'm not an IOS dev, but I needed to make this change to build.