### PR TITLE
[Performance] Decrease memory usage by 80% in some cases + Make parsing/decryption faster

### DIFF
--- a/ObjectivePGP/ObjectivePGPObject.h
+++ b/ObjectivePGP/ObjectivePGPObject.h
@@ -109,6 +109,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (nullable NSData *)decrypt:(NSData *)data andVerifySignature:(BOOL)verifySignature usingKeys:(NSArray<PGPKey *> *)keys passphraseForKey:(nullable NSString * _Nullable(^NS_NOESCAPE)(PGPKey * _Nullable key))passphraseBlock error:(NSError * __autoreleasing _Nullable *)error;
 
++ (nullable NSData *)decrypt:(NSData *)data verified:(BOOL * _Nullable)verified usingKeys:(NSArray<PGPKey *> *)keys passphraseForKey:(nullable NSString * _Nullable(^NS_NOESCAPE)(PGPKey * _Nullable key))passphraseForKeyBlock decryptionError:(NSError * __autoreleasing _Nullable *)decryptionError verificationError:(NSError * __autoreleasing _Nullable *)verificationError;
+
 
 /**
  Return list of key identifiers used in the given message. Determine keys that a message has been encrypted.

--- a/ObjectivePGP/ObjectivePGPObject.m
+++ b/ObjectivePGP/ObjectivePGPObject.m
@@ -94,6 +94,9 @@ NS_ASSUME_NONNULL_BEGIN
     // parse packets
     var packets = [ObjectivePGP readPacketsFromData:binaryMessage];
     packets = [self decryptPackets:packets usingKeys:keys passphrase:passphraseForKeyBlock error:decryptionError];
+    if (decryptionError && *decryptionError) {
+        return nil;
+    }
 
     // If the packet list of a message contains multiple literal packets, the first literal packet should
     // be considered as the correct one and any additional literal packets should be ignored.
@@ -113,9 +116,8 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     // Verify
-    BOOL isVerified = verified ? [self verifyPackets:packets usingKeys:keys passphraseForKey:passphraseForKeyBlock error:verificationError] : NO;
     if (verified) {
-        *verified = isVerified;
+        *verified = [self verifyPackets:packets usingKeys:keys passphraseForKey:passphraseForKeyBlock error:verificationError];
     }
 
     return plaintextData;

--- a/ObjectivePGP/PGPArmor.m
+++ b/ObjectivePGP/PGPArmor.m
@@ -142,7 +142,7 @@ NS_ASSUME_NONNULL_BEGIN
     scanner.charactersToBeSkipped = nil;
     
     NSCharacterSet *newlineSet = [NSCharacterSet newlineCharacterSet];
-    NSCharacterSet *invertedSet = [[NSCharacterSet newlineCharacterSet] invertedSet];
+    NSCharacterSet *notNewlineSet = [[NSCharacterSet newlineCharacterSet] invertedSet];
 
     // check header line
     NSString *headerLine = nil;
@@ -168,8 +168,8 @@ NS_ASSUME_NONNULL_BEGIN
 
     if (![scanner scanCharactersFromSet:newlineSet intoString:nil]) {
         // Scan headers (Optional)
-        [scanner scanUpToCharactersFromSet:invertedSet intoString:nil];
-        while ([scanner scanCharactersFromSet:invertedSet intoString:&line]) {
+        [scanner scanUpToCharactersFromSet:notNewlineSet intoString:nil];
+        while ([scanner scanCharactersFromSet:notNewlineSet intoString:&line]) {
             // consume newline
             [scanner scanString:@"\r" intoString:nil];
             [scanner scanString:@"\n" intoString:nil];


### PR DESCRIPTION
Armor / de-armor / decrypt was consuming 1GB+ memory on decrypting a 16MB email. This brings it down to ~100MB.