### PR TITLE
Avoid access to NULL pointer by returning early

### DIFF
--- a/ObjectivePGP/PGPPacketFactory.m
+++ b/ObjectivePGP/PGPPacketFactory.m
@@ -126,6 +126,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         if (!packet) {
             PGPLogError(@"Invalid message.");
+            return nil;
         }
 
         if (indeterminateLength) {


### PR DESCRIPTION
Fixes an access to a pointer being NULL.

Checklist:
- [x] I accept the [CONTRIBUTING.md](https://github.com/krzyzanowskim/ObjectivePGP/blob/master/CONTRIBUTING.md) terms.
- [x] Correct file headers (see CONTRIBUTING.md).
- [ ] Tests.

If the variable `packet` is `NULL` a log entry is created but the function does not return. Later a possible access to the variable could be made. An early return after the logging avoids this.