### PR TITLE
use autorelease pool during PGPS2K iteration to reduce peak memory usage

### DIFF
--- a/ObjectivePGP/PGPS2K.m
+++ b/ObjectivePGP/PGPS2K.m
@@ -146,15 +146,17 @@ static const unsigned int PGP_DEFAULT_ITERATIONS_COUNT = 215;
                 // then iterate
                 int iterations = 0;
                 while (iterations * data.length < codedCount) {
-                    let nextTotalLength = (iterations + 1) * data.length;
-                    if (nextTotalLength > codedCount) {
-                        let totalLength = iterations * data.length;
-                        let remainder = [data subdataWithRange:(NSRange){0, codedCount - totalLength}];
-                        update(remainder.bytes, (int)remainder.length);
-                    } else {
-                        update(data.bytes, (int)data.length);
+                    @autoreleasepool {
+                        let nextTotalLength = (iterations + 1) * data.length;
+                        if (nextTotalLength > codedCount) {
+                            let totalLength = iterations * data.length;
+                            let remainder = [data subdataWithRange:(NSRange){0, codedCount - totalLength}];
+                            update(remainder.bytes, (int)remainder.length);
+                        } else {
+                            update(data.bytes, (int)data.length);
+                        }
+                        iterations++;
                     }
-                    iterations++;
                 }
             };
         } break;


### PR DESCRIPTION
This fixes a problem where signing Git commits would require more than 10MB memory which isn't available for some app extensions on iOS causing the app extension to crash.

I presume most users of ObjectivePGP are not as memory constrained as me, but using less memory shouldn't hurt.

Checklist:
- [x] I accept the [CONTRIBUTING.md](https://github.com/krzyzanowskim/ObjectivePGP/blob/master/CONTRIBUTING.md) terms.
- [x] Correct file headers (see CONTRIBUTING.md).
- [x] Tests.

Changes proposed in this pull request:
-
