### PR TITLE
Revert "use autorelease pool during PGPS2K iteration to reduce peak m…

### DIFF
--- a/ObjectivePGP/PGPS2K.m
+++ b/ObjectivePGP/PGPS2K.m
@@ -146,17 +146,15 @@ static const unsigned int PGP_DEFAULT_ITERATIONS_COUNT = 215;
                 // then iterate
                 int iterations = 0;
                 while (iterations * data.length < codedCount) {
-                    @autoreleasepool {
-                        let nextTotalLength = (iterations + 1) * data.length;
-                        if (nextTotalLength > codedCount) {
-                            let totalLength = iterations * data.length;
-                            let remainder = [data subdataWithRange:(NSRange){0, codedCount - totalLength}];
-                            update(remainder.bytes, (int)remainder.length);
-                        } else {
-                            update(data.bytes, (int)data.length);
-                        }
-                        iterations++;
+                    let nextTotalLength = (iterations + 1) * data.length;
+                    if (nextTotalLength > codedCount) {
+                        let totalLength = iterations * data.length;
+                        let remainder = [data subdataWithRange:(NSRange){0, codedCount - totalLength}];
+                        update(remainder.bytes, (int)remainder.length);
+                    } else {
+                        update(data.bytes, (int)data.length);
                     }
+                    iterations++;
                 }
             };
         } break;


### PR DESCRIPTION
…emory usage"

Fixes #

Checklist:
- [ ] I accept the [CONTRIBUTING.md](https://github.com/krzyzanowskim/ObjectivePGP/blob/master/CONTRIBUTING.md) terms.
- [ ] Correct file headers (see CONTRIBUTING.md).
- [ ] Tests.

Changes proposed in this pull request:
-
