### PR TITLE
Enabling encrypt only algorithms to encrypt.

### DIFF
--- a/ObjectivePGP/Packets/PGPPublicKeyEncryptedSessionKeyPacket.m
+++ b/ObjectivePGP/Packets/PGPPublicKeyEncryptedSessionKeyPacket.m
@@ -238,6 +238,7 @@ NS_ASSUME_NONNULL_BEGIN
     [bodyData appendBytes:&_publicKeyAlgorithm length:1]; // 1
 
     switch (self.publicKeyAlgorithm) {
+        case PGPPublicKeyAlgorithmRSAEncryptOnly:
         case PGPPublicKeyAlgorithmRSA: {
             let exportedMPIData = [[self encryptedMPI:PGPMPI_M] exportMPI];
             if (!exportedMPIData) {
@@ -263,7 +264,6 @@ NS_ASSUME_NONNULL_BEGIN
         }
         break;
         case PGPPublicKeyAlgorithmDSA:
-        case PGPPublicKeyAlgorithmRSAEncryptOnly:
         case PGPPublicKeyAlgorithmRSASignOnly:
         case PGPPublicKeyAlgorithmElliptic:
         case PGPPublicKeyAlgorithmECDSA:


### PR DESCRIPTION
Using a public sub key that only supports encryption was crashing on Swift with "Cannot export ESK. Invalid packet.".

It seems that `PGPPublicKeyEncryptedSessionKeyPacket.m` was assuming `PGPPublicKeyAlgorithmRSAEncryptOnly` doesn't work for encryption. 

After the change the crash is gone and data is being encrypted.

Example of the PGP key:

```
-----BEGIN PGP MESSAGE-----
Comment: Encrypted by DMSOpenPGP

hQEMA1k1UxH7AeWvAggAgCmw3ZaR/plYSuAtG7WRbxhXeuj89fbS3UJG6nEwGv31
XrZkStQC8SM3cWQU+uXKjzWhhWXX8kqDbkq0V0UqQEpSFo8ZrDmv9jYw/7YK8C4n
/53tLyPKfMmQoNg+okevoa92s4iYNEZ9kWGgPORkToxu06h6LX7YWAsil0z9itGA
UQrJHq6GOgaZrtnxsmZwJpL0LvJLmYwS9K56B7Fyu9nKy1uh6XjLCPuIpCyk2Muz
GwZKTfjcuv9TzohF5PNcqM0isZDUt+0rYxRnwqLN0NjBwR9yYhes0mwlroIZobsP
K2PRiP3Lv27Pe3NArFvCGXhQQpNPgdKXj3eHw5GNatLCFQHQ/Pd39UDtUNaAMcHW
pDiv4PDWDVcL1Q98vaopljmC/cnfrJnN9NaVP6yl8IaolkjDgqwD50qE2lsB+al6
E1hli3j6C/W5ejhPCFR1pMmWt+jTa7L4xGaqFmxzkMbTxu1iZeyOx2YGz0H82LVn
QNgJzDfa4/7ztkkUx5CY794f5qQyQYxKDILu1PoSusnXO3oj4zeX36NM6FklOaaz
ttLBRCYGbDNSpPMK7ZXcOvhn7V0r2RVhPAj9pIbBjIR5RASbHOjLMV+W3QbAuzy6
PeD+J3cFqGKP/X0wL3+1CQ5G9VN4Hs44mZCyP2SuSzMyS2tAIw3ImCWAIOR+PIBT
Ea72eMEYp27ciST+AXv9Z9e+AWgY4rWlYq727kyC0FWC7dLb5RN13gOpanVzdr+5
xrnpNPLIz22US1jFMYd22QcqS+3x9SNy9WrC1ykg+v2k5iXWQkEWLqxyxm8HRBOg
w+HAeUlelf8kWE1JQ7w14KSS0hXg/yuqTyxOAhKyWlOIgBiGKCovKUoz3OpgE0CO
dKNOqtWpbB2a3IW3RNcyCIqZD6zJJIVqTvFJOBdJtMMWnbCnPaUg9CcsrVASPW5J
PRhB0MPSvwlqXTzmVvwzq15aFIPHeReMe1VHBJElAXPSbDbiwS49UAFkQ2j+mXOK
Iiwn5SP+mp/jDsPyxEu/k1TPmBkb9FxV5RM+hXFGyJiYRgrJOpZ3GYTPcUNO1BOh
LRTU0h4IIFv4XnOQmRZLZw0FZA7disJFmCnXYeHNDqWQBYPV1pqb0KIEvy/1IBzu
9lsKTCTnN51KYTXL0fhGvRn42QK7mdqzEEAXz6m53BfdFXBU+yshXRyqhOjzO89q
lxvH3RTk7vvB5qZklpjoNMInbeDYGpD91L5aCuCxlNkGsy8j4jmBP2HLjmz0vcMh
KNiDWo4x2w7NJhSDrPrZGJ+VHHOrLnnVmFJMfuaFImX29i9GOc44
=7RmT
-----END PGP MESSAGE-----
```

Checklist:
- [X] I accept the [CONTRIBUTING.md](https://github.com/krzyzanowskim/ObjectivePGP/blob/master/CONTRIBUTING.md) terms.
- [X] Correct file headers (see CONTRIBUTING.md).
- [ ] Tests.