### PR TITLE
Fixing an issue where a secret subkey wasn't being used to decrypt

### DIFF
--- a/ObjectivePGP/PGPPartialKey.m
+++ b/ObjectivePGP/PGPPartialKey.m
@@ -312,8 +312,8 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     for (PGPPartialSubKey *subKey in self.subKeys) {
-        let signaturePacket = subKey.bindingSignature;
-        if (signaturePacket.canBeUsedToEncrypt && PGPEqualObjects(PGPCast(subKey.primaryKeyPacket, PGPSecretKeyPacket).keyID, keyID)) {
+        //Assume the primary key packet is always capable if if its a secret key packet
+        if (PGPEqualObjects(PGPCast(subKey.primaryKeyPacket, PGPSecretKeyPacket).keyID, keyID)) {
             return PGPCast(subKey.primaryKeyPacket, PGPSecretKeyPacket);
         }
     }


### PR DESCRIPTION
In the case where a secret key was used only to sign and a secret subkey was then used to encrypt only, this function wasn't finding any keys to encrypt.

Similarly to how it is assumed on line 322, I changed the code to assume a secret subkey is always capable.

Checklist:
- [X] I accept the [CONTRIBUTING.md](https://github.com/krzyzanowskim/ObjectivePGP/blob/master/CONTRIBUTING.md) terms.
- [X] Correct file headers (see CONTRIBUTING.md).
- [ ] Tests.
